### PR TITLE
feat: add clients api controller

### DIFF
--- a/src/ProjeX.Blazor/Components/Pages/Clients/ClientList.razor
+++ b/src/ProjeX.Blazor/Components/Pages/Clients/ClientList.razor
@@ -3,6 +3,7 @@
 @using LastMinute.Consultancy.Application.Client
 @using Syncfusion.Blazor.Grids
 @using Syncfusion.Blazor.Popups
+@using Syncfusion.Blazor.Notifications
 @attribute [Authorize(Policy = "ManagerOrAdmin")]
 @inject IClientService ClientService
 @inject NavigationManager Navigation
@@ -83,10 +84,14 @@ else
     </DialogButtons>
 </SfDialog>
 
+<SfToast @ref="toastObj" Title="Error" CssClass="e-toast-danger" Timeout="5000" ShowProgressBar="false"></SfToast>
+
 @code {
     private List<ClientDto>? clients;
     private bool showDeleteDialog = false;
     private ClientDto? selectedClient;
+    private SfToast? toastObj;
+    private string? errorMessage;
 
     protected override async Task OnInitializedAsync()
     {
@@ -101,8 +106,8 @@ else
         }
         catch (Exception ex)
         {
-            // TODO: Add proper error handling/logging
-            Console.WriteLine($"Error loading clients: {ex.Message}");
+            errorMessage = $"Error loading clients: {ex.Message}";
+            await ShowErrorAsync();
         }
     }
 
@@ -131,9 +136,17 @@ else
             }
             catch (Exception ex)
             {
-                // TODO: Add proper error handling/notification
-                Console.WriteLine($"Error deleting client: {ex.Message}");
+                errorMessage = $"Error deleting client: {ex.Message}";
+                await ShowErrorAsync();
             }
+        }
+    }
+
+    private async Task ShowErrorAsync()
+    {
+        if (toastObj != null && !string.IsNullOrEmpty(errorMessage))
+        {
+            await toastObj.ShowAsync(new ToastModel { Content = errorMessage });
         }
     }
 }

--- a/src/ProjeX.Blazor/Controllers/ClientsController.cs
+++ b/src/ProjeX.Blazor/Controllers/ClientsController.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using LastMinute.Consultancy.Application.Client;
+using LastMinute.Consultancy.Application.Client.Commands;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace ProjeX.Blazor.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize(Policy = "ManagerOrAdmin")]
+    public class ClientsController : ControllerBase
+    {
+        private readonly IClientService _clientService;
+        private readonly ILogger<ClientsController> _logger;
+
+        public ClientsController(IClientService clientService, ILogger<ClientsController> logger)
+        {
+            _clientService = clientService;
+            _logger = logger;
+        }
+
+        [HttpGet]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+        public async Task<ActionResult<IEnumerable<ClientDto>>> GetAll()
+        {
+            try
+            {
+                var clients = await _clientService.GetAllAsync();
+                return Ok(clients);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error retrieving clients");
+                return Problem("An error occurred while retrieving clients.", statusCode: StatusCodes.Status500InternalServerError);
+            }
+        }
+
+        [HttpGet("{id:guid}")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+        public async Task<ActionResult<ClientDto>> Get(Guid id)
+        {
+            try
+            {
+                var client = await _clientService.GetByIdAsync(id);
+                if (client == null)
+                {
+                    return NotFound();
+                }
+                return Ok(client);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error retrieving client {ClientId}", id);
+                return Problem("An error occurred while retrieving the client.", statusCode: StatusCodes.Status500InternalServerError);
+            }
+        }
+
+        [HttpPost]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+        public async Task<ActionResult<ClientDto>> Create([FromBody] CreateClientCommand command)
+        {
+            try
+            {
+                var created = await _clientService.CreateAsync(command);
+                return CreatedAtAction(nameof(Get), new { id = created.Id }, created);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error creating client");
+                return Problem("An error occurred while creating the client.", statusCode: StatusCodes.Status500InternalServerError);
+            }
+        }
+
+        [HttpPut("{id:guid}")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> Update(Guid id, [FromBody] UpdateClientCommand command)
+        {
+            if (id != command.Id)
+            {
+                return BadRequest();
+            }
+
+            try
+            {
+                await _clientService.UpdateAsync(command);
+                return NoContent();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error updating client {ClientId}", id);
+                return Problem("An error occurred while updating the client.", statusCode: StatusCodes.Status500InternalServerError);
+            }
+        }
+
+        [HttpDelete("{id:guid}")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> Delete(Guid id)
+        {
+            try
+            {
+                await _clientService.DeleteAsync(id);
+                return NoContent();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error deleting client {ClientId}", id);
+                return Problem("An error occurred while deleting the client.", statusCode: StatusCodes.Status500InternalServerError);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add REST API controller for managing clients
- return ProblemDetails for server errors in client endpoints
- display Syncfusion toast notifications for client list errors

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4bef32a4883268c40491160a5fca0