### PR TITLE
feat: Update all services and Razor components to use userId for CreatedBy/ModifiedBy

### DIFF
--- a/src/ProjeX.Application/ActualAssignment/IAssignmentService.cs
+++ b/src/ProjeX.Application/ActualAssignment/IAssignmentService.cs
@@ -4,8 +4,8 @@ namespace ProjeX.Application.ActualAssignment
 {
     public interface IAssignmentService
     {
-        Task<AssignmentCreationResult> CreateAsync(CreateActualAssignmentCommand command, string userId);
-        Task ApproveAsync(Guid assignmentId, string approverUserId);
+       Task<AssignmentCreationResult> CreateAsync(CreateActualAssignmentCommand command, string userId);
+       Task ApproveAsync(Guid assignmentId, string approverUserId);
         Task RejectAsync(Guid assignmentId, string approverUserId, string reason);
         Task UnassignAsync(UnassignActualAssignmentCommand command, string userId);
         Task<List<ActualAssignmentDto>> GetAssignmentsAsync(Guid? projectId, Guid? employeeId);

--- a/src/ProjeX.Application/Budget/BudgetService.cs
+++ b/src/ProjeX.Application/Budget/BudgetService.cs
@@ -132,7 +132,7 @@ namespace ProjeX.Application.Budget
             return true;
         }
 
-        public async Task<bool> ApproveBudgetAsync(Guid id, Guid approvedById)
+        public async Task<bool> ApproveBudgetAsync(Guid id, string approvedById)
         {
             var budget = await _context.Budgets.FindAsync(id);
             if (budget == null)

--- a/src/ProjeX.Application/Budget/IBudgetService.cs
+++ b/src/ProjeX.Application/Budget/IBudgetService.cs
@@ -11,7 +11,7 @@ namespace ProjeX.Application.Budget
         Task<BudgetDto> CreateAsync(CreateBudgetRequest request, string userId);
         Task<BudgetDto> UpdateAsync(UpdateBudgetRequest request, string userId);
         Task<bool> DeleteAsync(Guid id);
-        Task<bool> ApproveBudgetAsync(Guid id, Guid approvedById);
+        Task<bool> ApproveBudgetAsync(Guid id, string approvedById);
         Task<decimal> GetTotalBudgetByProjectAsync(Guid projectId);
         Task<decimal> GetTotalBudgetByCategoryAsync(Guid projectId, BudgetCategory category);
         Task<IEnumerable<BudgetDto>> GetBudgetsByDateRangeAsync(DateTime startDate, DateTime endDate);

--- a/src/ProjeX.Application/ChangeRequest/ChangeRequestService.cs
+++ b/src/ProjeX.Application/ChangeRequest/ChangeRequestService.cs
@@ -19,7 +19,7 @@ namespace ProjeX.Application.ChangeRequest
             _mapper = mapper;
         }
 
-        public async Task<ChangeRequestDto> RaiseAsync(RaiseChangeRequestCommand request)
+        public async Task<ChangeRequestDto> RaiseAsync(RaiseChangeRequestCommand request, string userId)
         {
             var project = await _context.Projects
                 .FirstOrDefaultAsync(p => p.Id == request.ProjectId && !p.IsDeleted);
@@ -47,7 +47,9 @@ namespace ProjeX.Application.ChangeRequest
                 RequestedBy = request.RequestedBy,
                 BusinessJustification = request.Justification,
                 CreatedAt = DateTime.UtcNow,
-                CreatedBy = "system"
+                CreatedBy = userId,
+                ModifiedBy = userId,
+                ModifiedAt = DateTime.UtcNow
             };
 
             _context.ChangeRequests.Add(changeRequest);

--- a/src/ProjeX.Application/ChangeRequest/IChangeRequestService.cs
+++ b/src/ProjeX.Application/ChangeRequest/IChangeRequestService.cs
@@ -6,8 +6,8 @@ namespace ProjeX.Application.ChangeRequest
 {
     public interface IChangeRequestService
     {
-        Task<ChangeRequestDto> RaiseAsync(RaiseChangeRequestCommand command);
-        Task<ChangeRequestDto> ProcessAsync(ProcessChangeRequestCommand command);
+        Task<ChangeRequestDto> RaiseAsync(RaiseChangeRequestCommand command, string userId);
+        Task<ChangeRequestDto> ProcessAsync(ProcessChangeRequestCommand command, string userId);
     }
 }
 

--- a/src/ProjeX.Application/Client/ClientService.cs
+++ b/src/ProjeX.Application/Client/ClientService.cs
@@ -31,7 +31,7 @@ namespace ProjeX.Application.Client
             return client != null ? _mapper.Map<ClientDto>(client) : null;
         }
 
-        public async Task<ClientDto> CreateAsync(CreateClientCommand command, string userId)
+       public async Task<ClientDto> CreateAsync(CreateClientCommand command, string userId)
         {
             var entity = new Domain.Entities.Client
             {
@@ -54,7 +54,7 @@ namespace ProjeX.Application.Client
             return _mapper.Map<ClientDto>(entity);
         }
 
-        public async Task UpdateAsync(UpdateClientCommand command, string userId)
+       public async Task UpdateAsync(UpdateClientCommand command, string userId)
         {
             var entity = await _context.Clients.FindAsync(command.Id);
             if (entity == null)

--- a/src/ProjeX.Application/Client/IClientService.cs
+++ b/src/ProjeX.Application/Client/IClientService.cs
@@ -10,7 +10,7 @@ namespace ProjeX.Application.Client
         Task<List<ClientDto>> GetAllAsync();
         Task<ClientDto?> GetByIdAsync(Guid id);
         Task<ClientDto> CreateAsync(CreateClientCommand command, string userId);
-        Task UpdateAsync(UpdateClientCommand command, string userId);
+       Task UpdateAsync(UpdateClientCommand command, string userId);
         Task DeleteAsync(Guid id);
     }
 }

--- a/src/ProjeX.Application/Deliverable/DeliverableService.cs
+++ b/src/ProjeX.Application/Deliverable/DeliverableService.cs
@@ -37,7 +37,7 @@ namespace ProjeX.Application.Deliverable
             return deliverable != null ? _mapper.Map<DeliverableDto>(deliverable) : null;
         }
 
-        public async Task<DeliverableDto> CreateAsync(CreateDeliverableCommand command)
+        public async Task<DeliverableDto> CreateAsync(CreateDeliverableCommand command, string userId)
         {
             var entity = new Domain.Entities.Deliverable
             {
@@ -46,7 +46,11 @@ namespace ProjeX.Application.Deliverable
                 Name = command.Title,
                 Description = command.Description,
                 DueDate = command.DueDate,
-                Status = command.Status
+                Status = command.Status,
+                CreatedBy = userId,
+                CreatedAt = DateTime.UtcNow,
+                ModifiedBy = userId,
+                ModifiedAt = DateTime.UtcNow
             };
 
             _context.Deliverables.Add(entity);
@@ -55,7 +59,7 @@ namespace ProjeX.Application.Deliverable
             return _mapper.Map<DeliverableDto>(entity);
         }
 
-        public async Task UpdateAsync(UpdateDeliverableCommand command)
+        public async Task UpdateAsync(UpdateDeliverableCommand command, string userId)
         {
             var entity = await _context.Deliverables.FindAsync(command.Id);
 
@@ -69,6 +73,8 @@ namespace ProjeX.Application.Deliverable
             entity.Description = command.Description;
             entity.DueDate = command.DueDate;
             entity.Status = command.Status;
+            entity.ModifiedBy = userId;
+            entity.ModifiedAt = DateTime.UtcNow;
 
             await _context.SaveChangesAsync();
         }

--- a/src/ProjeX.Application/Deliverable/IDeliverableService.cs
+++ b/src/ProjeX.Application/Deliverable/IDeliverableService.cs
@@ -9,8 +9,8 @@ namespace ProjeX.Application.Deliverable
     {
         Task<List<DeliverableDto>> GetAllAsync();
         Task<DeliverableDto?> GetByIdAsync(Guid id);
-        Task<DeliverableDto> CreateAsync(CreateDeliverableCommand command);
-        Task UpdateAsync(UpdateDeliverableCommand command);
+        Task<DeliverableDto> CreateAsync(CreateDeliverableCommand command, string userId);
+        Task UpdateAsync(UpdateDeliverableCommand command, string userId);
         Task DeleteAsync(Guid id);
     }
 }

--- a/src/ProjeX.Application/Employee/IEmployeeService.cs
+++ b/src/ProjeX.Application/Employee/IEmployeeService.cs
@@ -6,8 +6,8 @@ namespace ProjeX.Application.Employee
     {
         Task<List<EmployeeDto>> GetAllAsync();
         Task<EmployeeDto?> GetByIdAsync(Guid id);
-        Task<EmployeeDto> CreateAsync(CreateEmployeeCommand command, string userId);
-        Task UpdateAsync(UpdateEmployeeCommand command, string userId);
+      Task<EmployeeDto> CreateAsync(CreateEmployeeCommand command, string userId);
+       Task UpdateAsync(UpdateEmployeeCommand command, string userId);
         Task DeleteAsync(Guid id);
     }
 }

--- a/src/ProjeX.Application/Invoice/InvoiceService.cs
+++ b/src/ProjeX.Application/Invoice/InvoiceService.cs
@@ -21,7 +21,7 @@ namespace ProjeX.Application.Invoice
             _mapper = mapper;
         }
 
-        public async Task<InvoiceDto> PlanAsync(PlanInvoiceCommand request)
+        public async Task<InvoiceDto> PlanAsync(PlanInvoiceCommand request, string userId)
         {
             var project = await _context.Projects
                 .Include(p => p.Client)
@@ -52,7 +52,9 @@ namespace ProjeX.Application.Invoice
                 Status = InvoiceStatus.Planned,
                 Notes = request.Notes,
                 CreatedAt = DateTime.UtcNow,
-                CreatedBy = "system"
+                CreatedBy = userId,
+                ModifiedBy = userId,
+                ModifiedAt = DateTime.UtcNow
             };
 
             _context.Invoices.Add(invoice);
@@ -69,7 +71,9 @@ namespace ProjeX.Application.Invoice
                     Amount = lineItemRequest.Quantity * lineItemRequest.UnitPrice,
                     Type = lineItemRequest.LineItemType,
                     CreatedAt = DateTime.UtcNow,
-                    CreatedBy = "system"
+                    CreatedBy = userId,
+                    ModifiedBy = userId,
+                    ModifiedAt = DateTime.UtcNow
                 };
                 _context.InvoiceLineItems.Add(lineItem);
             }
@@ -85,7 +89,7 @@ namespace ProjeX.Application.Invoice
             return _mapper.Map<InvoiceDto>(savedInvoice);
         }
 
-        public async Task<InvoiceDto> ConfirmAsync(ConfirmInvoiceCommand request)
+        public async Task<InvoiceDto> ConfirmAsync(ConfirmInvoiceCommand request, string userId)
         {
             var invoice = await _context.Invoices
                 .Include(i => i.Project)
@@ -105,14 +109,14 @@ namespace ProjeX.Application.Invoice
             invoice.Status = InvoiceStatus.Issued;
             invoice.Notes += $"\n\nConfirmed and issued on {DateTime.UtcNow:yyyy-MM-dd}: {request.ConfirmationNotes}";
             invoice.ModifiedAt = DateTime.UtcNow;
-            invoice.ModifiedBy = "system";
+            invoice.ModifiedBy = userId;
 
             await _context.SaveChangesAsync();
 
             return _mapper.Map<InvoiceDto>(invoice);
         }
 
-        public async Task<InvoiceDto> CancelAsync(CancelInvoiceCommand request)
+        public async Task<InvoiceDto> CancelAsync(CancelInvoiceCommand request, string userId)
         {
             var invoice = await _context.Invoices
                 .Include(i => i.Project)
@@ -132,7 +136,7 @@ namespace ProjeX.Application.Invoice
             invoice.Status = InvoiceStatus.Cancelled;
             invoice.Notes += $"\n\nCancelled on {DateTime.UtcNow:yyyy-MM-dd}: {request.CancellationReason}";
             invoice.ModifiedAt = DateTime.UtcNow;
-            invoice.ModifiedBy = "system";
+            invoice.ModifiedBy = userId;
 
             await _context.SaveChangesAsync();
 

--- a/src/ProjeX.Application/InvoicePlanning/IInvoicePlanService.cs
+++ b/src/ProjeX.Application/InvoicePlanning/IInvoicePlanService.cs
@@ -2,8 +2,8 @@ namespace ProjeX.Application.InvoicePlanning
 {
     public interface IInvoicePlanService
     {
-        Task<InvoicePlanDto> CreateAsync(CreateInvoicePlanRequest request);
-        Task<InvoicePlanDto> UpdateAsync(UpdateInvoicePlanRequest request);
+        Task<InvoicePlanDto> CreateAsync(CreateInvoicePlanRequest request, string userId);
+        Task<InvoicePlanDto> UpdateAsync(UpdateInvoicePlanRequest request, string userId);
         Task<InvoicePlanDto?> GetByIdAsync(Guid id);
         Task<IEnumerable<InvoicePlanDto>> GetByProjectIdAsync(Guid projectId);
         Task<IEnumerable<InvoiceScheduleDto>> GetUpcomingInvoicesAsync(DateTime fromDate, DateTime toDate);

--- a/src/ProjeX.Application/Overhead/IOverheadService.cs
+++ b/src/ProjeX.Application/Overhead/IOverheadService.cs
@@ -9,8 +9,8 @@ namespace ProjeX.Application.Overhead
     {
         Task<List<OverheadDto>> GetAllAsync();
         Task<OverheadDto?> GetByIdAsync(Guid id);
-        Task<OverheadDto> CreateAsync(CreateOverheadCommand command);
-        Task UpdateAsync(UpdateOverheadCommand command);
+        Task<OverheadDto> CreateAsync(CreateOverheadCommand command, string userId);
+        Task UpdateAsync(UpdateOverheadCommand command, string userId);
         Task DeleteAsync(Guid id);
     }
 }

--- a/src/ProjeX.Application/Overhead/OverheadService.cs
+++ b/src/ProjeX.Application/Overhead/OverheadService.cs
@@ -37,7 +37,7 @@ namespace ProjeX.Application.Overhead
             return overhead != null ? _mapper.Map<OverheadDto>(overhead) : null;
         }
 
-        public async Task<OverheadDto> CreateAsync(CreateOverheadCommand command)
+        public async Task<OverheadDto> CreateAsync(CreateOverheadCommand command, string userId)
         {
             var entity = new Domain.Entities.Overhead
             {
@@ -46,7 +46,11 @@ namespace ProjeX.Application.Overhead
                 Amount = command.Amount,
                 Date = command.Date,
                 Category = command.Category,
-                ProjectId = command.ProjectId
+                ProjectId = command.ProjectId,
+                CreatedBy = userId,
+                CreatedAt = DateTime.UtcNow,
+                ModifiedBy = userId,
+                ModifiedAt = DateTime.UtcNow
             };
 
             _context.Overheads.Add(entity);
@@ -55,7 +59,7 @@ namespace ProjeX.Application.Overhead
             return _mapper.Map<OverheadDto>(entity);
         }
 
-        public async Task UpdateAsync(UpdateOverheadCommand command)
+        public async Task UpdateAsync(UpdateOverheadCommand command, string userId)
         {
             var entity = await _context.Overheads.FindAsync(command.Id);
 
@@ -69,6 +73,8 @@ namespace ProjeX.Application.Overhead
             entity.Date = command.Date;
             entity.Category = command.Category;
             entity.ProjectId = command.ProjectId;
+            entity.ModifiedBy = userId;
+            entity.ModifiedAt = DateTime.UtcNow;
 
             await _context.SaveChangesAsync();
         }

--- a/src/ProjeX.Application/Path/IPathService.cs
+++ b/src/ProjeX.Application/Path/IPathService.cs
@@ -5,8 +5,8 @@ namespace ProjeX.Application.Path
         Task<IEnumerable<PathDto>> GetAllAsync();
         Task<IEnumerable<PathDto>> GetByProjectIdAsync(Guid projectId);
         Task<PathDto?> GetByIdAsync(Guid id);
-        Task<PathDto> CreateAsync(CreatePathRequest request);
-        Task<PathDto> UpdateAsync(UpdatePathRequest request);
+        Task<PathDto> CreateAsync(CreatePathRequest request, string userId);
+        Task<PathDto> UpdateAsync(UpdatePathRequest request, string userId);
         Task<bool> DeleteAsync(Guid id);
         Task<bool> ValidatePathAllocationAsync(Guid projectId, decimal allocationPercentage, Guid? excludePathId = null);
         Task<decimal> GetTotalProjectAllocationAsync(Guid projectId);

--- a/src/ProjeX.Application/Path/PathService.cs
+++ b/src/ProjeX.Application/Path/PathService.cs
@@ -53,7 +53,7 @@ namespace ProjeX.Application.Path
             return path != null ? _mapper.Map<PathDto>(path) : null;
         }
 
-        public async Task<PathDto> CreateAsync(CreatePathRequest request)
+        public async Task<PathDto> CreateAsync(CreatePathRequest request, string userId)
         {
             // Validate project exists
             var project = await _context.Projects.FindAsync(request.ProjectId);
@@ -66,6 +66,10 @@ namespace ProjeX.Application.Path
                 throw new InvalidOperationException("Total path allocation would exceed 100%");
 
             var path = _mapper.Map<Domain.Entities.Path>(request);
+            path.CreatedBy = userId;
+            path.CreatedAt = DateTime.UtcNow;
+            path.ModifiedBy = userId;
+            path.ModifiedAt = DateTime.UtcNow;
             
             _context.Paths.Add(path);
             await _context.SaveChangesAsync();
@@ -85,6 +89,8 @@ namespace ProjeX.Application.Path
                 throw new InvalidOperationException("Total path allocation would exceed 100%");
 
             _mapper.Map(request, path);
+            path.ModifiedBy = userId;
+            path.ModifiedAt = DateTime.UtcNow;
             
             await _context.SaveChangesAsync();
 

--- a/src/ProjeX.Blazor/Components/Pages/Clients/ClientForm.razor
+++ b/src/ProjeX.Blazor/Components/Pages/Clients/ClientForm.razor
@@ -8,6 +8,10 @@
 @attribute [Authorize(Policy = "ManagerOrAdmin")]
 @inject IClientService ClientService
 @inject NavigationManager Navigation
+@inject AuthenticationStateProvider AuthenticationStateProvider
+@inject UserManager<ApplicationUser> UserManager
+@using Microsoft.AspNetCore.Components.Authorization
+@using ProjeX.Domain.Entities
 
 <PageTitle>@(IsEdit ? "Edit Client" : "Create Client") - ProjeX</PageTitle>
 
@@ -120,9 +124,19 @@
     private bool isSubmitting = false;
 
     private bool IsEdit => Id.HasValue;
+    private string? currentUserId;
 
     protected override async Task OnInitializedAsync()
     {
+        var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+        var user = authState.User;
+
+        if (user.Identity?.IsAuthenticated == true)
+        {
+            var appUser = await UserManager.GetUserAsync(user);
+            currentUserId = appUser?.Id;
+        }
+
         if (IsEdit && Id.HasValue)
         {
             await LoadClient(Id.Value);
@@ -177,7 +191,7 @@
                     Address = model.Address,
                     Status = model.Status
                 };
-                await ClientService.UpdateAsync(updateCommand);
+                await ClientService.UpdateAsync(updateCommand, currentUserId);
             }
             else
             {
@@ -190,7 +204,7 @@
                     Address = model.Address,
                     Status = model.Status
                 };
-                await ClientService.CreateAsync(createCommand);
+                await ClientService.CreateAsync(createCommand, currentUserId);
             }
 
             Navigation.NavigateTo("/clients");

--- a/src/ProjeX.Blazor/Components/Pages/Deliverables/DeliverableForm.razor
+++ b/src/ProjeX.Blazor/Components/Pages/Deliverables/DeliverableForm.razor
@@ -12,6 +12,10 @@
 @inject IDeliverableService DeliverableService
 @inject IProjectService ProjectService
 @inject NavigationManager Navigation
+@inject AuthenticationStateProvider AuthenticationStateProvider
+@inject UserManager<ApplicationUser> UserManager
+@using Microsoft.AspNetCore.Components.Authorization
+@using ProjeX.Domain.Entities
 
 <PageTitle>@(IsEdit ? "Edit" : "Create") Deliverable - ProjeX</PageTitle>
 
@@ -104,9 +108,19 @@
     private List<StatusOption> statusOptions = new();
     private bool isSubmitting = false;
     private SfToast? toastObj;
+    private string? currentUserId;
 
     protected override async Task OnInitializedAsync()
     {
+        var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+        var user = authState.User;
+
+        if (user.Identity?.IsAuthenticated == true)
+        {
+            var appUser = await UserManager.GetUserAsync(user);
+            currentUserId = appUser?.Id;
+        }
+
         await LoadProjects();
         LoadStatusOptions();
 
@@ -188,11 +202,11 @@
                 updateCommand.DueDate = command.DueDate;
                 updateCommand.Status = command.Status;
 
-                await DeliverableService.UpdateAsync(updateCommand);
+                await DeliverableService.UpdateAsync(updateCommand, currentUserId);
             }
             else
             {
-                await DeliverableService.CreateAsync(command);
+                await DeliverableService.CreateAsync(command, currentUserId);
             }
 
             Navigation.NavigateTo("/deliverables");

--- a/src/ProjeX.Blazor/Components/Pages/Overheads/OverheadForm.razor
+++ b/src/ProjeX.Blazor/Components/Pages/Overheads/OverheadForm.razor
@@ -13,6 +13,10 @@
 @inject IOverheadService OverheadService
 @inject IProjectService ProjectService
 @inject NavigationManager Navigation
+@inject AuthenticationStateProvider AuthenticationStateProvider
+@inject UserManager<ApplicationUser> UserManager
+@using Microsoft.AspNetCore.Components.Authorization
+@using ProjeX.Domain.Entities
 
 <PageTitle>@(IsEdit ? "Edit" : "Create") Overhead - ProjeX</PageTitle>
 
@@ -114,9 +118,19 @@
     private List<CategoryOption> categoryOptions = new();
     private bool isSubmitting = false;
     private SfToast? toastObj;
+    private string? currentUserId;
 
     protected override async Task OnInitializedAsync()
     {
+        var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+        var user = authState.User;
+
+        if (user.Identity?.IsAuthenticated == true)
+        {
+            var appUser = await UserManager.GetUserAsync(user);
+            currentUserId = appUser?.Id;
+        }
+
         await LoadProjects();
         LoadCategoryOptions();
 
@@ -198,11 +212,11 @@
                 updateCommand.Category = command.Category;
                 updateCommand.ProjectId = command.ProjectId;
 
-                await OverheadService.UpdateAsync(updateCommand);
+                await OverheadService.UpdateAsync(updateCommand, currentUserId);
             }
             else
             {
-                await OverheadService.CreateAsync(command);
+                await OverheadService.CreateAsync(command, currentUserId);
             }
 
             Navigation.NavigateTo("/overheads");

--- a/src/ProjeX.Blazor/Components/Pages/Paths/PathList.razor
+++ b/src/ProjeX.Blazor/Components/Pages/Paths/PathList.razor
@@ -8,6 +8,10 @@
 @inject IPathService PathService
 @inject IEmployeeService EmployeeService
 @inject IProjectService ProjectService
+@inject AuthenticationStateProvider AuthenticationStateProvider
+@inject UserManager<ApplicationUser> UserManager
+@using Microsoft.AspNetCore.Components.Authorization
+@using ProjeX.Domain.Entities
 
 <PageTitle>Project Paths - ProjeX</PageTitle>
 
@@ -256,9 +260,19 @@
     private bool isLoading = false;
     private bool isSubmitting = false;
     private string selectedProjectId = string.Empty;
+    private string? currentUserId;
 
     protected override async System.Threading.Tasks.Task OnInitializedAsync()
     {
+        var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+        var user = authState.User;
+
+        if (user.Identity?.IsAuthenticated == true)
+        {
+            var appUser = await UserManager.GetUserAsync(user);
+            currentUserId = appUser?.Id;
+        }
+
         await LoadProjects();
         await LoadEmployees();
         await LoadPaths();
@@ -371,11 +385,11 @@ if (isEdit)
    updateRequest.Notes = pathRequest.Notes;
     updateRequest.IsActive = pathRequest.IsActive;
            
-       await PathService.UpdateAsync(updateRequest);
+            await PathService.UpdateAsync(updateRequest, currentUserId);
 }
             else
      {
-          await PathService.CreateAsync(pathRequest);
+          await PathService.CreateAsync(pathRequest, currentUserId);
 }
 
       await LoadPaths();

--- a/src/ProjeX.Infrastructure/Interceptors/AuditInterceptor.cs
+++ b/src/ProjeX.Infrastructure/Interceptors/AuditInterceptor.cs
@@ -38,15 +38,11 @@ namespace ProjeX.Infrastructure.Interceptors
                 if (entry.State == EntityState.Added)
                 {
                     entry.Entity.CreatedAt = DateTime.UtcNow;
-                    entry.Entity.CreatedBy = currentUser;
-                    entry.Entity.ModifiedBy = currentUser; // Set ModifiedBy for new entities
-                    entry.Entity.ModifiedAt = DateTime.UtcNow; // Set ModifiedAt for new entities
                 }
 
                 if (entry.State == EntityState.Modified)
                 {
                     entry.Entity.ModifiedAt = DateTime.UtcNow;
-                    entry.Entity.ModifiedBy = currentUser;
                 }
             }
         }


### PR DESCRIPTION
This PR updates all services and their corresponding Razor components to accept a  parameter for  and  fields. The  has been modified to no longer set these fields, delegating the responsibility to the services themselves. Additionally, Razor components have been updated to pass the current authenticated user's ID to these service methods.