### PR TITLE
Add current user service and integrate into time entry pages

### DIFF
--- a/src/ProjeX.Application/Common/Interfaces/ICurrentUserService.cs
+++ b/src/ProjeX.Application/Common/Interfaces/ICurrentUserService.cs
@@ -1,0 +1,9 @@
+using ProjeX.Domain.Entities;
+
+namespace ProjeX.Application.Common.Interfaces
+{
+    public interface ICurrentUserService
+    {
+        Task<ApplicationUser> GetCurrentUserAsync();
+    }
+}

--- a/src/ProjeX.Blazor/Components/Pages/TimeEntries/TimeEntryForm.razor
+++ b/src/ProjeX.Blazor/Components/Pages/TimeEntries/TimeEntryForm.razor
@@ -6,9 +6,11 @@
 @using ProjeX.Domain.Enums
 @using System.ComponentModel.DataAnnotations
 @using Syncfusion.Blazor.Calendars
+@using ProjeX.Application.Common.Interfaces
 @attribute [Authorize]
 @inject ITimeEntryService TimeEntryService
 @inject NavigationManager Navigation
+@inject ICurrentUserService CurrentUserService
 
 <PageTitle>@(IsEdit ? "Edit Time Entry" : "Log Time") - ProjeX</PageTitle>
 
@@ -152,6 +154,7 @@
         isSubmitting = true;
         try
         {
+            var currentUser = await CurrentUserService.GetCurrentUserAsync();
             if (IsEdit)
             {
                 var updateCommand = new UpdateTimeEntryCommand
@@ -164,7 +167,7 @@
                     IsBillable = model.IsBillable,
                     BillableRate = model.BillableRate
                 };
-                await TimeEntryService.UpdateAsync(updateCommand, "current-user"); // TODO: Get actual user ID
+                await TimeEntryService.UpdateAsync(updateCommand, currentUser.Id);
             }
             else
             {
@@ -177,7 +180,7 @@
                     IsBillable = model.IsBillable,
                     BillableRate = model.BillableRate
                 };
-                await TimeEntryService.CreateAsync(createCommand, "current-user"); // TODO: Get actual user ID
+                await TimeEntryService.CreateAsync(createCommand, currentUser.Id);
             }
 
             Navigation.NavigateTo("/time-entries");

--- a/src/ProjeX.Blazor/Components/Pages/TimeEntries/TimeEntryList.razor
+++ b/src/ProjeX.Blazor/Components/Pages/TimeEntries/TimeEntryList.razor
@@ -1,10 +1,12 @@
 @page "/time-entries"
 @using Microsoft.AspNetCore.Authorization
 @using ProjeX.Application.TimeEntry
+@using ProjeX.Application.Common.Interfaces
 @using Syncfusion.Blazor.Grids
 @using Syncfusion.Blazor.Popups
 @attribute [Authorize]
 @inject ITimeEntryService TimeEntryService
+@inject ICurrentUserService CurrentUserService
 @inject NavigationManager Navigation
 
 <PageTitle>Time Entries - ProjeX</PageTitle>
@@ -149,7 +151,8 @@ else
         {
             try
             {
-                await TimeEntryService.DeleteAsync(selectedTimeEntry.Id, "current-user"); // TODO: Get actual user ID
+                var currentUser = await CurrentUserService.GetCurrentUserAsync();
+                await TimeEntryService.DeleteAsync(selectedTimeEntry.Id, currentUser.Id);
                 await LoadTimeEntries();
                 showDeleteDialog = false;
                 selectedTimeEntry = null;

--- a/src/ProjeX.Blazor/Program.cs
+++ b/src/ProjeX.Blazor/Program.cs
@@ -22,6 +22,8 @@ using ProjeX.Application.Path;
 using ProjeX.Application.Budget;
 using ProjeX.Infrastructure.Services;
 using ProjeX.Infrastructure.Interceptors;
+using ProjeX.Application.Common.Interfaces;
+using ProjeX.Infrastructure.Identity;
 using Syncfusion.Blazor;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -29,6 +31,7 @@ var builder = WebApplication.CreateBuilder(args);
 // Add services needed for interceptors
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddScoped<AuditInterceptor>();
+builder.Services.AddScoped<ICurrentUserService, CurrentUserService>();
 
 // Add Entity Framework with audit interceptor
 builder.Services.AddDbContext<ApplicationDbContext>((serviceProvider, options) =>

--- a/src/ProjeX.Infrastructure/Identity/CurrentUserService.cs
+++ b/src/ProjeX.Infrastructure/Identity/CurrentUserService.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using ProjeX.Application.Common.Interfaces;
+using ProjeX.Domain.Entities;
+
+namespace ProjeX.Infrastructure.Identity
+{
+    public class CurrentUserService : ICurrentUserService
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public CurrentUserService(UserManager<ApplicationUser> userManager, IHttpContextAccessor httpContextAccessor)
+        {
+            _userManager = userManager;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        public async Task<ApplicationUser> GetCurrentUserAsync()
+        {
+            var principal = _httpContextAccessor.HttpContext?.User;
+            return await _userManager.GetUserAsync(principal!)!;
+        }
+    }
+}

--- a/src/ProjeX.Infrastructure/ProjeX.Infrastructure.csproj
+++ b/src/ProjeX.Infrastructure/ProjeX.Infrastructure.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ProjeX.Domain\ProjeX.Domain.csproj" />
+    <ProjectReference Include="..\ProjeX.Application\ProjeX.Application.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Add `ICurrentUserService` in application layer.
- Implement `CurrentUserService` using `UserManager` and `IHttpContextAccessor`.
- Register current user service and use it in time entry pages for user-aware operations.

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c59bf2935483268f26aa3f47e95982