### PR TITLE
Add base component and current user service

### DIFF
--- a/src/ProjeX.Application/Identity/ICurrentUserService.cs
+++ b/src/ProjeX.Application/Identity/ICurrentUserService.cs
@@ -1,0 +1,9 @@
+using ProjeX.Domain.Entities;
+
+namespace ProjeX.Application.Identity
+{
+    public interface ICurrentUserService
+    {
+        Task<ApplicationUser?> GetCurrentUserAsync();
+    }
+}

--- a/src/ProjeX.Blazor/Components/Pages/Account/Register.razor
+++ b/src/ProjeX.Blazor/Components/Pages/Account/Register.razor
@@ -3,7 +3,6 @@
 @using ProjeX.Domain.Entities
 @using System.ComponentModel.DataAnnotations
 @using System.Threading.Tasks
-@inject UserManager<ApplicationUser> UserManager
 @inject SignInManager<ApplicationUser> SignInManager
 @inject NavigationManager NavigationManager
 @rendermode InteractiveServer
@@ -109,7 +108,7 @@ try
    Email = model.Email
          };
 
-   var result = await UserManager.CreateAsync(user, model.Password);
+    var result = await SignInManager.UserManager.CreateAsync(user, model.Password);
 
          if (result.Succeeded)
        {

--- a/src/ProjeX.Blazor/Components/_Imports.razor
+++ b/src/ProjeX.Blazor/Components/_Imports.razor
@@ -10,3 +10,5 @@
 @using ProjeX.Blazor
 @using ProjeX.Blazor.Components
 @using static Microsoft.AspNetCore.Components.Web.RenderMode
+@using ProjeX.Blazor.Shared
+@inherits BaseComponent

--- a/src/ProjeX.Blazor/Program.cs
+++ b/src/ProjeX.Blazor/Program.cs
@@ -20,6 +20,7 @@ using ProjeX.Application.Payment;
 using ProjeX.Application.Reports;
 using ProjeX.Application.Path;
 using ProjeX.Application.Budget;
+using ProjeX.Application.Identity;
 using ProjeX.Infrastructure.Services;
 using ProjeX.Infrastructure.Interceptors;
 using Syncfusion.Blazor;
@@ -109,6 +110,8 @@ builder.Services.AddScoped<IInvoiceService, InvoiceService>();
 builder.Services.AddScoped<IReportService, ReportService>();
 builder.Services.AddScoped<IPathService, PathService>();
 builder.Services.AddScoped<IBudgetService, BudgetService>();
+
+builder.Services.AddScoped<ICurrentUserService, CurrentUserService>();
 
 // Add authorization policies
 builder.Services.AddAuthorization(options =>

--- a/src/ProjeX.Blazor/Shared/BaseComponent.cs
+++ b/src/ProjeX.Blazor/Shared/BaseComponent.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Authorization;
+using ProjeX.Application.Identity;
+using ProjeX.Domain.Entities;
+
+namespace ProjeX.Blazor.Shared
+{
+    public class BaseComponent : ComponentBase
+    {
+        [CascadingParameter]
+        protected Task<AuthenticationState> AuthenticationStateTask { get; set; } = default!;
+
+        [Inject]
+        protected ICurrentUserService CurrentUserService { get; set; } = default!;
+
+        protected ApplicationUser? CurrentUser { get; private set; }
+
+        protected override async Task OnInitializedAsync()
+        {
+            var authState = await AuthenticationStateTask;
+            if (authState.User.Identity?.IsAuthenticated == true)
+            {
+                CurrentUser = await CurrentUserService.GetCurrentUserAsync();
+            }
+        }
+    }
+}

--- a/src/ProjeX.Infrastructure/Services/CurrentUserService.cs
+++ b/src/ProjeX.Infrastructure/Services/CurrentUserService.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using ProjeX.Application.Identity;
+using ProjeX.Domain.Entities;
+using System.Security.Claims;
+
+namespace ProjeX.Infrastructure.Services
+{
+    public class CurrentUserService : ICurrentUserService
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public CurrentUserService(UserManager<ApplicationUser> userManager, IHttpContextAccessor httpContextAccessor)
+        {
+            _userManager = userManager;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        public async Task<ApplicationUser?> GetCurrentUserAsync()
+        {
+            var userId = _httpContextAccessor.HttpContext?.User?.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (string.IsNullOrWhiteSpace(userId))
+            {
+                return null;
+            }
+
+            return await _userManager.FindByIdAsync(userId);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add shared BaseComponent with cascading auth state and CurrentUser helper
- introduce ICurrentUserService and its implementation to resolve ApplicationUser
- wire up service and remove direct UserManager injection from Register page

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c59d864e288326ad639407b174cf11